### PR TITLE
[UPDATE] logic to select next_img_id 次に推定する画像を選択するロジックの変更

### DIFF
--- a/accounts/models.py
+++ b/accounts/models.py
@@ -6,7 +6,7 @@ import random
 
 def init_img_list():
     """img_idsのlistをcharで保持"""
-    return ','.join([str(i) for i in range(30)])
+    return ','.join([str(i) for i in range(15)])
 
 
 # Create your models here.
@@ -31,13 +31,18 @@ class User(AbstractUser):
         if finished:
             num_finished_imgとuse_systemを更新
         """
+        if finished:
+            self.num_finished_img += 1
+            if self.num_finished_img == 15:
+                self.use_system = not self.use_system
+                self.char_img_ids = init_img_list()
+            if self.num_finished_img == 30:
+                return
+
         list_img_ids = (self.char_img_ids).split(',')
         sampled_id = random.choice(list_img_ids)
 
         self.next_img_id = int(sampled_id)
         list_img_ids.remove(sampled_id)
         self.char_img_ids = ','.join(list_img_ids)
-        if finished:
-            self.num_finished_img += 1
-            if self.num_finished_img == 15:
-                self.use_system = not self.use_system
+        return

--- a/img_processing/views/manual.py
+++ b/img_processing/views/manual.py
@@ -55,7 +55,10 @@ def submit(request, user_id, predict):
 
         predict = request.POST['predict']
         with transaction.atomic():
-            processing = get_object_or_404(ImageProcessing, user=user, img_id=user.next_img_id)
+            processing = get_object_or_404(ImageProcessing,
+                                           user=user,
+                                           img_id=user.next_img_id,
+                                           use_system=user.use_system)
             processing.predict = predict
             processing.save()
             user.set_next_img_id()

--- a/img_processing/views/use_system.py
+++ b/img_processing/views/use_system.py
@@ -129,7 +129,10 @@ def submit(request, user_id):
 
         predict = estimate.get_predict_from_csv(f'media/processing_data/user_{user.id}/df_n.csv')
         with transaction.atomic():
-            processing = get_object_or_404(ImageProcessing, user=user, img_id=user.next_img_id)
+            processing = get_object_or_404(ImageProcessing,
+                                           user=user,
+                                           img_id=user.next_img_id,
+                                           use_system=user.use_system)
             processing.predict = predict
             processing.save()
             shutil.move(


### PR DESCRIPTION
# 次に推定する画像を選択するロジックの変更
### OverViewing
目的: 
* 15枚の画像をシステム利用・非利用で2周分ランダムに選ぶロジックに変更
  * 15枚からランダムで選択
  * 15枚選択し尽くすとプールをリセットしてもう1周

ポイント:
* image_processingのレコードがuse_system=[True, False]の2種類登場する仕様になったため，user_idとimg_idに加えuse_systemも取得条件に追加
* 

### Item (add, delete, fix)
省略
### Comments
ローカル環境で動作確認済み