### PR TITLE
[FIX] behavior on signup redirect

### DIFF
--- a/accounts/templates/signup.html
+++ b/accounts/templates/signup.html
@@ -2,7 +2,7 @@
 {% load django_bootstrap5 %}
 
 {% block content %}
-{% if request.META.HTTP_REFERER == 'http://localhost:9001/agree/' or request.META.HTTP_REFERER == 'https://flwapp.imlab.jp/agree/' %}
+{% if request.META.HTTP_REFERER == 'http://localhost:9001/agree/' or request.META.HTTP_REFERER == 'https://flwapp.imlab.jp/agree/' or request.META.HTTP_REFERER == 'https://flwapp.imlab.jp/signup/'%}
     <h1>User Registration</h1>
     <form action="{% url 'signup' %}" method="post">
     {% csrf_token %}


### PR DESCRIPTION
# signupにおけるリダイレクトの有効化
### OverViewing
目的: 
* signupからリダイレクトした際の挙動を変更

ポイント:
* agreeを飛ばしてsignupのURL直打ちで登録されることを防ぐためにsignupに遷移する前のURLを制限していた
* signupからのリダイレクトも制限してしまう問題を解消